### PR TITLE
Fix: check framework manifest if no plugins in db (fixes #32)

### DIFF
--- a/lib/ContentPluginModule.js
+++ b/lib/ContentPluginModule.js
@@ -145,13 +145,12 @@ class ContentPluginModule extends AbstractApiModule {
    * @return {Promise}
    */
   async initPlugins () {
-    await this.syncPluginData()
-
     const missing = await this.getMissingPlugins()
     if (missing.length) { // note we're using CLI directly, as plugins already exist in the DB
       this.log('debug', 'MISSING', missing)
       await this.framework.runCliCommand('installPlugins', { plugins: missing })
     }
+    await this.syncPluginData()
     await this.processPluginSchemas()
   }
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#32 

[//]: # (Delete as appropriate)
### Fix
* check framework manifest if no plugins in db (fixes #32)

