### PR TITLE
Reload schemas after plugin update (fixes #37)

### DIFF
--- a/lib/ContentPluginModule.js
+++ b/lib/ContentPluginModule.js
@@ -358,6 +358,7 @@ class ContentPluginModule extends AbstractApiModule {
     const [{ name }] = await this.find({ _id })
     const [pluginData] = await this.framework.runCliCommand('updatePlugins', { plugins: [name] })
     const p = await this.update({ name }, pluginData._sourceInfo)
+    await this.processPluginSchemas(pluginData)
     this.log('info', `successfully updated plugin ${p.name}@${p.version}`)
     return p
   }


### PR DESCRIPTION
Fixes #37

[//]: # (Add a link to the original issue)

[//]: # (Delete as appropriate)
### Fix
* Makes sure schemas are reloaded after a plugin has been updated


