### PR TITLE
Fix: Make sure processPluginSchemas param is always an Array (fixes #52)

### DIFF
--- a/lib/ContentPluginModule.js
+++ b/lib/ContentPluginModule.js
@@ -190,12 +190,15 @@ class ContentPluginModule extends AbstractApiModule {
 
   /**
    * Loads and processes all installed content plugin schemas
-   * @param {Array} pluginInfo Plugin info data
+   * @param {Array|Object} pluginInfo Plugin info data
    * @return {Promise}
    */
   async processPluginSchemas (pluginInfo) {
     if (!pluginInfo) {
       pluginInfo = await this.framework.runCliCommand('getPluginUpdateInfos')
+    }
+    if (!Array.isArray(pluginInfo)) {
+      pluginInfo = [pluginInfo]
     }
     const jsonschema = await this.app.waitForModule('jsonschema')
     return Promise.all(pluginInfo.map(async plugin => {
@@ -319,7 +322,7 @@ class ContentPluginModule extends AbstractApiModule {
       throw this.app.errors.CONTENTPLUGIN_ATTR_MISSING
         .setData({ name })
     }
-    await this.processPluginSchemas([data])
+    await this.processPluginSchemas(data)
     return info
   }
 


### PR DESCRIPTION
Fixes #52

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Delete as appropriate)
### Fix
* Make sure ContentPluginModule#processPluginSchemas param is always an Array


