### PR TITLE
Fix: Resolve circular dependency deadlock with content module

### DIFF
--- a/lib/ContentPluginModule.js
+++ b/lib/ContentPluginModule.js
@@ -45,7 +45,7 @@ class ContentPluginModule extends AbstractApiModule {
     if (!process.env.ADAPT_ALLOW_PRERELEASE) {
       process.env.ADAPT_ALLOW_PRERELEASE = 'true'
     }
-    const [framework, mongodb, content] = await this.app.waitForModule('adaptframework', 'mongodb', 'content')
+    const [framework, mongodb] = await this.app.waitForModule('adaptframework', 'mongodb')
 
     await mongodb.setIndex(this.collectionName, 'name', { unique: true })
     await mongodb.setIndex(this.collectionName, 'displayName', { unique: true })
@@ -61,7 +61,9 @@ class ContentPluginModule extends AbstractApiModule {
     } catch (e) {
       this.log('error', e)
     }
-    content.preInsertHook.tap((...args) => addDefaultPlugins(this, ...args))
+    this.app.waitForModule('content').then(content => {
+      content.preInsertHook.tap((...args) => addDefaultPlugins(this, ...args))
+    })
     this.framework.postInstallHook.tap(this.syncPluginData.bind(this))
     this.framework.postUpdateHook.tap(this.syncPluginData.bind(this))
   }

--- a/lib/ContentPluginModule.js
+++ b/lib/ContentPluginModule.js
@@ -61,11 +61,11 @@ class ContentPluginModule extends AbstractApiModule {
     } catch (e) {
       this.log('error', e)
     }
+    this.framework.postInstallHook.tap(this.syncPluginData.bind(this))
+    this.framework.postUpdateHook.tap(this.syncPluginData.bind(this))
     this.app.waitForModule('content').then(content => {
       content.preInsertHook.tap((...args) => addDefaultPlugins(this, ...args))
     })
-    this.framework.postInstallHook.tap(this.syncPluginData.bind(this))
-    this.framework.postUpdateHook.tap(this.syncPluginData.bind(this))
   }
 
   /** @override */


### PR DESCRIPTION
## Summary
- v1.6.0 introduced `await this.app.waitForModule('content')` in `init()`, but the `content` module also awaits `contentplugin` during its init, creating a circular deadlock where neither module can signal ready
- Replaced the `await` with `.then()` so the `preInsertHook` tap happens asynchronously after `content` is ready, allowing `contentplugin` to complete init and break the cycle

## Test plan
- [ ] Verify app starts without `DEP_TIMEOUT` for `adapt-authoring-content`
- [ ] Verify content plugin default plugins are still added on content insert
- [ ] Verify plugin sync works after framework install/update

🤖 Generated with [Claude Code](https://claude.com/claude-code)