### PR TITLE
Fix: remove broken unused serveSchema override

### DIFF
--- a/lib/ContentPluginModule.js
+++ b/lib/ContentPluginModule.js
@@ -443,20 +443,6 @@ class ContentPluginModule extends AbstractApiModule {
     return p
   }
 
-  /** @override */
-  async serveSchema (req, res, next) {
-    try {
-      const plugin = await this.get({ name: req.apiData.query.type }) || {}
-      const schema = await this.getSchema(plugin.schemaName)
-      if (!schema) {
-        return next(this.app.errors.NO_SCHEMA_DEF)
-      }
-      res.type('application/schema+json').json(schema.built)
-    } catch (e) {
-      return next(e)
-    }
-  }
-
   /**
    * Express request handler for installing a plugin (also used for updating via zip upload).
    * @param {external:ExpressRequest} req


### PR DESCRIPTION
### Fixes #102

### Fix
- Remove the `serveSchema` override from `ContentPluginModule`. It was broken on two counts — it called a non-existent `this.get` (throws `TypeError`, always caught into `next(e)`), and read a `plugin.schemaName` field that is never persisted on a plugin record. Removing it lets the inherited `AbstractApiModule.serveSchema` default serve the `contentplugin` record schema, consistent with every other API module. The `/schema` route is unchanged.

**Note:** I have not been able to determine the override's intended functionality. It appears to have aimed at returning a per-plugin content schema, but it has never worked and no consumer could be found — content is authored only via the content API, which resolves plugin schemas itself. If there is intended behaviour here, this can be revisited.

### Testing
- `npx standard` passes
- All 54 module tests pass